### PR TITLE
remove namespace argument in kimera_vio_ros.launch

### DIFF
--- a/launch/kimera_vio_ros.launch
+++ b/launch/kimera_vio_ros.launch
@@ -138,7 +138,6 @@
   <include file="$(find pose_graph_tools)/launch/posegraph_view.launch" >
     <arg name="frame"         value="$(arg world_frame_id)" />
     <arg name="graph_topic"   value="pose_graph" />
-    <arg name="ns"            value="kimera_vio_ros"/>
   </include>
 
   <!-- Log ground-truth data only if requested-->


### PR DESCRIPTION
When posegraph_view.launch is included from kimera_vio_ros.launch, an argument "ns" is passed, which is not valid for posegraph_view.launch, causing the launch to fail.
