### PR TITLE
Fix issue #96

### DIFF
--- a/src/utils/UtilsRos.cpp
+++ b/src/utils/UtilsRos.cpp
@@ -59,7 +59,7 @@ void msgCamInfoToCameraParams(const sensor_msgs::CameraInfoConstPtr& cam_info,
   cam_params->camera_id_ = cam_info->header.frame_id;
   CHECK(!cam_params->camera_id_.empty());
 
-  cam_params->distortion_model_ = cam_info->distortion_model;
+  cam_params->distortion_model_ = stringToDistortion(cam_info->distortion_model, "pinhole");
 
   const std::vector<double>& distortion_coeffs = cam_info->D;
   CHECK_EQ(distortion_coeffs.size(), 4);

--- a/src/utils/UtilsRos.cpp
+++ b/src/utils/UtilsRos.cpp
@@ -59,12 +59,13 @@ void msgCamInfoToCameraParams(const sensor_msgs::CameraInfoConstPtr& cam_info,
   cam_params->camera_id_ = cam_info->header.frame_id;
   CHECK(!cam_params->camera_id_.empty());
 
-  cam_params->distortion_model_ = stringToDistortion(cam_info->distortion_model, "pinhole");
+  cam_params->distortion_model_ = CameraParams::stringToDistortion(cam_info->distortion_model, "pinhole");
 
   const std::vector<double>& distortion_coeffs = cam_info->D;
   CHECK_EQ(distortion_coeffs.size(), 4);
-  VIO::CameraParams::convertDistortionVectorToMatrix(
-      distortion_coeffs, &cam_params->distortion_coeff_);
+  cam_params->distortion_coeff_ = distortion_coeffs;
+  CameraParams::convertDistortionVectorToMatrix(
+      distortion_coeffs, &cam_params->distortion_coeff_mat_);
 
   cam_params->image_size_ = cv::Size(cam_info->width, cam_info->height);
 

--- a/src/utils/UtilsRos.cpp
+++ b/src/utils/UtilsRos.cpp
@@ -60,9 +60,6 @@ void msgCamInfoToCameraParams(const sensor_msgs::CameraInfoConstPtr& cam_info,
   CHECK(!cam_params->camera_id_.empty());
 
   cam_params->distortion_model_ = cam_info->distortion_model;
-  CHECK(cam_params->distortion_model_ == "radtan" ||
-        cam_params->distortion_model_ == "radial-tangential" ||
-        cam_params->distortion_model_ == "equidistant");
 
   const std::vector<double>& distortion_coeffs = cam_info->D;
   CHECK_EQ(distortion_coeffs.size(), 4);


### PR DESCRIPTION
The problem was with Kimera-VIO last update that removed the strings for distortion and replaced them for `enum class` instead: see `Kimera-VIO/include/kimera-vio/frontend/CameraParams.h`