### PR TITLE
compiling under Ubuntu 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.0)
 project(kimera_vio_ros)
 
 find_package(catkin_simple REQUIRED)

--- a/install/kimera_vio_ros_https.rosinstall
+++ b/install/kimera_vio_ros_https.rosinstall
@@ -13,7 +13,7 @@
 - git:
     local-name: gtsam
     uri: https://github.com/borglab/gtsam.git
-    version: master
+    version: 4.0.3
     # Last tested commit: 342f30d148fae84c92ff71705c9e50e0a3683bda
 - git:
     local-name: opencv3_catkin

--- a/install/kimera_vio_ros_ssh.rosinstall
+++ b/install/kimera_vio_ros_ssh.rosinstall
@@ -13,7 +13,7 @@
 - git:
     local-name: gtsam
     uri: git@github.com:borglab/gtsam.git
-    version: master
+    version: 4.0.3
 - git:
     local-name: opencv3_catkin
     uri: git@github.com:ethz-asl/opencv3_catkin.git


### PR DESCRIPTION
At the moment compilation of GTSAM fails under Ubuntu 20.04 due to the use of the "master" branch, which is outdated and does not compile under later versions of cmake, see #115 

This PR fixes this by using the GTSAM 4.0.3 tag instead of the master branch.
Further, the minimum requirement for cmake is set to 3.5.0 to suppress warning messages related to CMP0048.

Tested to be compiling under Ubuntu 16.04, 18.04, and 20.04.

Will break Ubuntu 14.04 (trusty), which uses cmake 2.8.x. (The workaround is to upgrade cmake:
https://askubuntu.com/questions/610291/how-to-install-cmake-3-2-on-ubuntu)