### PR TITLE
Removed extra bracket in realsense launch file

### DIFF
--- a/launch/kimera_vio_ros_realsense_IR.launch
+++ b/launch/kimera_vio_ros_realsense_IR.launch
@@ -13,7 +13,7 @@
 
   <!-- Only used when parsing a rosbag -->
   <arg name="rosbag_path" default="default.bag"
-       unless="$(arg online)"/>"/>
+       unless="$(arg online)"/>
 
   <!-- Frame IDs. These DO NOT match frame id's on the video streams, as the 
 	RealSense and Kimera publish conflicting Tf's -->


### PR DESCRIPTION
The realsense launch file had an extra bracket that was breaking the tf tree.