### PR TITLE
Add consistency check for visualization flags in KimeraVioRos & Remove redundant argument

### DIFF
--- a/launch/kimera_vio_ros.launch
+++ b/launch/kimera_vio_ros.launch
@@ -110,8 +110,6 @@ file and include this one to launch KimeraVIO on the dataset of your choice -->
   <arg name="include_pipeline_flags" default="false"/>
   <arg name="pipeline_flag_args" value="--flagfile=$(arg flags_folder)/Pipeline.flags"
        if="$(arg include_pipeline_flags)"/>
-  <arg name="pipeline_flag_args" value=""
-       unless="$(arg include_pipeline_flags)"/>
 
   <arg name="glog_dir" default=""/>
   <arg name="glog_to_dir" default="false"/>

--- a/src/KimeraVioRos.cpp
+++ b/src/KimeraVioRos.cpp
@@ -49,6 +49,10 @@ KimeraVioRos::KimeraVioRos()
       "restart_kimera_vio", &KimeraVioRos::restartKimeraVio, this);
 
   CHECK(nh_private_.getParam("use_rviz", use_rviz_));
+  // Check that visualization flags are consistent
+  CHECK_EQ(use_rviz_, FLAGS_visualize)
+      << "visualize flags must match: use_rviz_ and FLAGS_visualize should "
+         "be the same";
 
   nh_private_.getParam("use_lcd_registration_server",
                        use_lcd_registration_server_);
@@ -304,7 +308,8 @@ void KimeraVioRos::connectVIO() {
                 std::placeholders::_1));
 
   if (vio_params_->frontend_type_ == VIO::FrontendType::kStereoImu) {
-    auto stereo_pipeline = dynamic_cast<StereoImuPipeline*>(vio_pipeline_.get());
+    auto stereo_pipeline =
+        dynamic_cast<StereoImuPipeline*>(vio_pipeline_.get());
     CHECK(stereo_pipeline);
 
     data_provider_->registerRightFrameCallback(


### PR DESCRIPTION
- Check if `use_rviz` == `FLAGS_visualize`
- A bit formatting modification
---
2nd PR:
- Remove redundant pipeline flag argument, `pipeline_flag_args`, in `kimera_vio_ros.launch`